### PR TITLE
Implement basic lexical analysis as frontend crate `levoc-parser`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,7 @@ version = 4
 [[package]]
 name = "levoc"
 version = "0.1.0"
+
+[[package]]
+name = "levoc-lexer"
+version = "0.1.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,3 +9,12 @@ version = "0.1.0"
 [[package]]
 name = "levoc-lexer"
 version = "0.1.0"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"

--- a/crates/front/levoc-lexer/Cargo.toml
+++ b/crates/front/levoc-lexer/Cargo.toml
@@ -6,3 +6,4 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+unicode-ident = "1.0.18"

--- a/crates/front/levoc-lexer/Cargo.toml
+++ b/crates/front/levoc-lexer/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "levoc-lexer"
+version = "0.1.0"
+
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]

--- a/crates/front/levoc-lexer/src/cursor.rs
+++ b/crates/front/levoc-lexer/src/cursor.rs
@@ -1,0 +1,81 @@
+pub struct Cursor<'a> {
+    chars: std::str::Chars<'a>,
+    remain: usize,
+
+    #[cfg(debug_assertions)]
+    prev: Option<char>,
+}
+
+impl<'a> Cursor<'a> {
+    pub fn new(text: &'a str) -> Self {
+        Self {
+            chars: text.chars(),
+            remain: text.len(),
+
+            #[cfg(debug_assertions)]
+            prev: None,
+        }
+    }
+
+    pub(super) fn as_str(&self) -> &'a str {
+        self.chars.as_str()
+    }
+
+    pub(super) fn pos(&self) -> usize {
+        self.remain - self.as_str().len()
+    }
+
+    pub(super) fn prev(&self) -> Option<char> {
+        #[cfg(debug_assertions)]
+        {
+            self.prev
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            None
+        }
+    }
+}
+
+impl Cursor<'_> {
+    pub(super) fn rebase(&mut self) {
+        self.remain = self.as_str().len();
+    }
+
+    pub(super) fn bump(&mut self) -> Option<char> {
+        let ch = self.chars.next();
+        #[cfg(debug_assertions)]
+        {
+            self.prev = ch;
+        }
+
+        ch
+    }
+
+    pub(super) fn bump_nth(&mut self, n: usize) -> Option<char> {
+        let ch = self.chars.nth(n);
+        #[cfg(debug_assertions)]
+        {
+            self.prev = ch;
+        }
+
+        ch
+    }
+
+    pub(super) fn bump_while<P>(&mut self, pred: P)
+    where
+        P: Fn(char) -> bool,
+    {
+        while self.peek().is_some_and(&pred) {
+            _ = self.bump();
+        }
+    }
+
+    pub(super) fn peek(&self) -> Option<char> {
+        self.chars.clone().next()
+    }
+
+    pub(super) fn peek_nth(&self, n: usize) -> Option<char> {
+        self.chars.clone().nth(n)
+    }
+}

--- a/crates/front/levoc-lexer/src/lex.rs
+++ b/crates/front/levoc-lexer/src/lex.rs
@@ -1,0 +1,299 @@
+use super::cursor::Cursor;
+use crate::token::{Base::*, CommentKind::*, Delim::*, LitKind::*, Punc::*, Token, TokenKind, TokenKind::*};
+
+trait CharExt {
+    fn is_newline(self) -> bool;
+    fn is_space(self) -> bool;
+
+    fn is_ident_start(self) -> bool;
+    fn is_ident_continue(self) -> bool;
+}
+
+impl CharExt for char {
+    fn is_newline(self) -> bool {
+        matches!(self, '\n' | '\r' | '\u{0085}' | '\u{2028}' | '\u{2029}')
+    }
+
+    fn is_space(self) -> bool {
+        !self.is_newline() && self.is_whitespace()
+    }
+
+    fn is_ident_start(self) -> bool {
+        self == '_' || unicode_ident::is_xid_start(self)
+    }
+
+    fn is_ident_continue(self) -> bool {
+        unicode_ident::is_xid_continue(self)
+    }
+}
+
+impl Cursor<'_> {
+    pub fn next_token(&mut self) -> Option<Token> {
+        let kind = match self.bump()? {
+            ch if ch.is_whitespace() => self.eat_space(ch),
+            ch if ch.is_ident_start() => self.eat_ident(),
+            ch if ch.is_ascii_digit() => self.eat_num_lit(ch),
+
+            '/' => match self.peek() {
+                Some('/') => self.eat_line_comment(),
+                Some('*') => self.eat_block_comment(),
+                _ => Punc(Slash),
+            },
+
+            '"' => self.eat_str_lit(),
+            '\'' => self.eat_char_lit(),
+
+            '+' => Punc(Plus),
+            '-' => Punc(Minus),
+            '*' => Punc(Star),
+            '%' => Punc(Perc),
+
+            '&' => Punc(Amp),
+            '|' => Punc(Bar),
+            '^' => Punc(Caret),
+            '!' => Punc(Bang),
+
+            '=' => Punc(Eq),
+            '<' => Punc(Lt),
+            '>' => Punc(Gt),
+
+            '.' => Punc(Dot),
+            ',' => Punc(Comma),
+            ':' => Punc(Colon),
+            ';' => Punc(Semi),
+
+            '(' => Open(Paren),
+            '[' => Open(Brack),
+            '{' => Open(Brace),
+            ')' => Close(Paren),
+            ']' => Close(Brack),
+            '}' => Close(Brace),
+
+            _ => Unknown,
+        };
+
+        let token = Token::new(kind, self.pos());
+        self.rebase();
+        Some(token)
+    }
+
+    fn eat_space(&mut self, first: char) -> TokenKind {
+        debug_assert!(self.prev().is_some_and(|ch| ch.is_whitespace()));
+        if first.is_newline() {
+            if first == '\r' && self.peek().is_some_and(|ch| ch == '\n') {
+                _ = self.bump();
+            }
+
+            Newline
+        } else {
+            self.bump_while(|ch| ch.is_space());
+            Space
+        }
+    }
+
+    fn eat_line_comment(&mut self) -> TokenKind {
+        debug_assert!(self.prev() == Some('/') && self.peek() == Some('/'));
+        _ = self.bump();
+        let kind = match self.peek() {
+            Some('/') => OuterDoc,
+            Some('!') => InnerDoc,
+            _ => Normal,
+        };
+
+        self.bump_while(|ch| !ch.is_newline());
+        LineComment { kind }
+    }
+
+    fn eat_block_comment(&mut self) -> TokenKind {
+        debug_assert!(self.prev() == Some('/') && self.peek() == Some('*'));
+        _ = self.bump();
+
+        let kind = match self.peek() {
+            Some('*') => {
+                if self.peek_nth(1) == Some('/') {
+                    _ = self.bump_nth(1);
+                    return BlockComment { kind: Normal, terminated: true };
+                } else {
+                    OuterDoc
+                }
+            }
+            Some('!') => InnerDoc,
+            _ => Normal,
+        };
+
+        let mut depth: u32 = 1;
+        loop {
+            self.bump_while(|ch| !matches!(ch, '*' | '/'));
+            match (self.bump(), self.peek()) {
+                (None, _) | (_, None) => break,
+                (Some('/'), Some('*')) => {
+                    _ = self.bump();
+                    depth += 1
+                }
+                (Some('*'), Some('/')) => {
+                    _ = self.bump();
+                    depth -= 1;
+
+                    if depth <= 0 {
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        BlockComment { kind, terminated: depth <= 0 }
+    }
+
+    fn eat_ident(&mut self) -> TokenKind {
+        debug_assert!(self.prev().is_some_and(|ch| ch.is_ident_start()));
+        self.bump_while(|ch| ch.is_ident_continue());
+        Ident
+    }
+
+    fn eat_num_lit(&mut self, first: char) -> TokenKind {
+        debug_assert!(self.prev().is_some_and(|ch| ch.is_ascii_digit()));
+        let mut base = Decimal;
+        if first == '0' {
+            match self.peek() {
+                Some('b') => {
+                    base = Binary;
+                    _ = self.bump();
+                    if self.eat_decimal_digits() {
+                        return Lit { kind: Int { base, empty: true } };
+                    }
+                }
+                Some('o') => {
+                    base = Octal;
+                    _ = self.bump();
+                    if self.eat_decimal_digits() {
+                        return Lit { kind: Int { base, empty: true } };
+                    }
+                }
+                Some('x') => {
+                    base = Hexadecimal;
+                    _ = self.bump();
+                    if self.eat_hexadecimal_digits() {
+                        return Lit { kind: Int { base, empty: true } };
+                    }
+                }
+                _ => _ = self.eat_decimal_digits(),
+            }
+        } else {
+            _ = self.eat_decimal_digits();
+        }
+
+        let kind = match self.peek() {
+            Some('.') if self.peek_nth(1).is_some_and(|ch| ch.is_ascii_digit()) => {
+                _ = self.bump();
+                _ = self.eat_decimal_digits();
+                match self.peek() {
+                    Some('e' | 'E') => {
+                        _ = self.bump();
+                        Float { base, exp_empty: self.eat_float_lit_exp() }
+                    }
+                    _ => Float { base, exp_empty: false },
+                }
+            }
+            Some('e' | 'E') => {
+                _ = self.bump();
+                Float { base, exp_empty: self.eat_float_lit_exp() }
+            }
+            _ => Int { base, empty: false },
+        };
+
+        Lit { kind }
+    }
+
+    fn eat_decimal_digits(&mut self) -> bool {
+        let mut is_empty = true;
+        while let Some(ch) = self.peek() {
+            match ch {
+                ch if ch.is_ascii_digit() => {
+                    _ = self.bump();
+                    is_empty = false;
+                }
+                '_' => _ = self.bump(),
+
+                _ => break,
+            }
+        }
+
+        is_empty
+    }
+
+    fn eat_hexadecimal_digits(&mut self) -> bool {
+        let mut is_empty = true;
+        while let Some(ch) = self.peek() {
+            match ch {
+                ch if ch.is_ascii_hexdigit() => {
+                    _ = self.bump();
+                    is_empty = false;
+                }
+                '_' => _ = self.bump(),
+
+                _ => break,
+            }
+        }
+
+        is_empty
+    }
+
+    fn eat_float_lit_exp(&mut self) -> bool {
+        debug_assert!(self.prev().is_some_and(|ch| matches!(ch, 'e' | 'E')));
+        if matches!(self.peek(), Some('+' | '-')) {
+            _ = self.bump()
+        }
+
+        self.eat_decimal_digits()
+    }
+
+    fn eat_char_lit(&mut self) -> TokenKind {
+        debug_assert!(matches!(self.prev(), Some('\'')));
+        if self.peek_nth(1) == Some('\'') && self.peek() != Some('\\') {
+            self.bump_nth(1);
+            return Lit { kind: Char { terminated: true } };
+        }
+
+        let terminated = loop {
+            if let Some(ch) = self.peek() {
+                match ch {
+                    '\\' => _ = self.bump_nth(1),
+                    '\n' => break false,
+                    '\'' => {
+                        _ = self.bump();
+                        break true;
+                    }
+
+                    _ => _ = self.bump(),
+                }
+            } else {
+                break false;
+            }
+        };
+
+        Lit { kind: Char { terminated } }
+    }
+
+    fn eat_str_lit(&mut self) -> TokenKind {
+        debug_assert!(matches!(self.prev(), Some('"')));
+        let terminated = loop {
+            if let Some(ch) = self.peek() {
+                match ch {
+                    '\\' => _ = self.bump_nth(1),
+                    '\n' => break false,
+                    '"' => {
+                        _ = self.bump();
+                        break true;
+                    }
+
+                    _ => _ = self.bump(),
+                }
+            } else {
+                break false;
+            }
+        };
+
+        Lit { kind: Str { terminated } }
+    }
+}

--- a/crates/front/levoc-lexer/src/lib.rs
+++ b/crates/front/levoc-lexer/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod cursor;

--- a/crates/front/levoc-lexer/src/lib.rs
+++ b/crates/front/levoc-lexer/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod cursor;
+pub mod token;

--- a/crates/front/levoc-lexer/src/lib.rs
+++ b/crates/front/levoc-lexer/src/lib.rs
@@ -2,3 +2,6 @@ pub mod cursor;
 pub mod token;
 
 mod lex;
+
+#[cfg(test)]
+mod tests;

--- a/crates/front/levoc-lexer/src/lib.rs
+++ b/crates/front/levoc-lexer/src/lib.rs
@@ -1,2 +1,4 @@
 pub mod cursor;
 pub mod token;
+
+mod lex;

--- a/crates/front/levoc-lexer/src/tests.rs
+++ b/crates/front/levoc-lexer/src/tests.rs
@@ -1,0 +1,49 @@
+use crate::cursor::Cursor;
+
+#[test]
+fn lexer_general_tests() {
+    run_tests(&[
+        "", "a", "_", "_a", "abc", "\n", " ", "\r\n", "\n\n", "\r\n\r\n", "\u{2028}",
+    ]);
+}
+
+#[test]
+fn lexer_literal_tests() {
+    run_tests(&[
+        "1", "1_", "12", "0x11", "0b11", "0o11", "011", "0x", "0b", "0o", "0f", // int literals
+        "12.1", "12._1", "12.", "12e1", "12e+1", "12e-1", "12e+1_", "12e+_1", "1e", "1e+", "1e-", "1.1e1", "1.e1",
+        "0x1e.1e1", // float literals
+        "'a'", "'\\n'", "'abc'", "''", "'", "' \n", // char literals
+        r#""""#, r#"" ""#, r#""''""#, r#""\"""#, r#"""#, "\"\n\"", // str literals
+    ]);
+}
+
+#[test]
+fn lexer_expr_tests() {
+    run_tests(&["a + b", "a+b", "a+ b", "1 + 2", "+-*/%&|^!=<>.,:;", "()[]{}"]);
+}
+
+#[test]
+fn lexer_block_comment_tests() {
+    run_tests(&["/* */", "/** */", "/*! */", "/**/", "/*/**/*/"]);
+}
+
+#[test]
+fn lexer_block_comment_fails() {
+    run_tests(&["/*", "/*/**/", "*/", "/*/"]);
+}
+
+#[test]
+fn lexer_line_comment_tests() {
+    run_tests(&["//", "///", "//!", "// A", "// \n", "////"]);
+}
+
+fn run_tests(texts: &[&str]) {
+    for (num, text) in texts.into_iter().enumerate() {
+        println!(r#"#{num}: "{text}""#);
+        let mut cursor = Cursor::new(text);
+        std::iter::from_fn(|| cursor.next_token())
+            .enumerate()
+            .for_each(|(num, token)| println!("  #{num}: {token:?}"));
+    }
+}

--- a/crates/front/levoc-lexer/src/token.rs
+++ b/crates/front/levoc-lexer/src/token.rs
@@ -1,0 +1,83 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommentKind {
+    Normal,
+    OuterDoc,
+    InnerDoc,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Base {
+    Binary = 2,
+    Octal = 8,
+    Decimal = 10,
+    Hexadecimal = 16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LitKind {
+    Int { base: Base, empty: bool },
+    Float { base: Base, exp_empty: bool },
+
+    Char { terminated: bool },
+    Str { terminated: bool },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Punc {
+    Plus,  // +
+    Minus, // -
+    Star,  // *
+    Slash, // /
+    Perc,  // %
+
+    Amp,   // &
+    Bar,   // |
+    Caret, // ^
+    Bang,  // !
+
+    Eq, // =
+    Lt, // <
+    Gt, // >
+
+    Dot,   // .
+    Comma, // ,
+    Colon, // :
+    Semi,  // ;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Delim {
+    Paren, // ( )
+    Brack, // [ ]
+    Brace, // { }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Token {
+    pub len: usize,
+    pub kind: TokenKind,
+}
+
+impl Token {
+    pub fn new(kind: TokenKind, len: usize) -> Self {
+        Self { len, kind }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenKind {
+    Unknown,
+
+    Space,
+    Newline,
+
+    LineComment { kind: CommentKind },
+    BlockComment { kind: CommentKind, terminated: bool },
+
+    Ident,
+    Lit { kind: LitKind },
+
+    Punc(Punc),
+    Open(Delim),
+    Close(Delim),
+}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,7 @@
+group_imports = "StdExternalCrate"
+
+max_width = 120
+struct_lit_width = 50
+struct_variant_width = 50
+single_line_if_else_max_width = 65
+single_line_let_else_max_width = 65


### PR DESCRIPTION
This PR adds the crate `levoc-lexer` located at `crates/front/levoc-lexer`, which provides utilities for preliminary lexical analysis. Specifically, it offers the `Cursor` type, which takes in a `&str` and converts it into a series of lexical tokens to be consumed downstream by the parser.